### PR TITLE
add uart support

### DIFF
--- a/nodes/node_1/src/main.c
+++ b/nodes/node_1/src/main.c
@@ -1,15 +1,22 @@
 #include <stdbool.h>
-#include <util/delay.h>
+#include <stdio.h>
 
 #include "usart.h"
 
 int main()
 {
-    usart_init(9600);
-    usart_send_string("Epstein didn't kill himself\n");
 
+    FILE *uart0 = usart_init(9600);
+    char buffer[256] = {0};
     while (true)
     {
-        _delay_ms(1000);
+        printf("Listening...\n\r");
+        fgets(buffer, 30, uart0);
+        printf("received: %s\n\r", buffer);
     }
+
+    while (1)
+    {
+    }
+
 }

--- a/nodes/node_1/src/main.c
+++ b/nodes/node_1/src/main.c
@@ -2,17 +2,16 @@
 #include <util/delay.h>
 
 #include "gpio.h"
-
-#define DELAY 1000 // one second
+#include "usart.h"
 
 int main()
 {
+    usart_init(9600);
     DDRB = (GPIO_OUTPUT << DDB0);
+
+    usart_send_string("Epstein didn't kill himself\n");
     while (true)
     {
-        PORTB = (GPIO_LOW << PB0);
-        _delay_ms(DELAY);
-        PORTB = (GPIO_HIGH << PB0);
-        _delay_ms(DELAY);
+        _delay_ms(1000);
     }
 }

--- a/nodes/node_1/src/main.c
+++ b/nodes/node_1/src/main.c
@@ -1,15 +1,13 @@
 #include <stdbool.h>
 #include <util/delay.h>
 
-#include "gpio.h"
 #include "usart.h"
 
 int main()
 {
     usart_init(9600);
-    DDRB = (GPIO_OUTPUT << DDB0);
-
     usart_send_string("Epstein didn't kill himself\n");
+
     while (true)
     {
         _delay_ms(1000);

--- a/nodes/node_1/src/modules/gpio.c
+++ b/nodes/node_1/src/modules/gpio.c
@@ -1,0 +1,13 @@
+#include "gpio.h"
+
+// this will not work because _MMIO_BYTE macro inside avr/sfr_defs.h dereferences all addresses making it impossible to pass it around as an address
+
+// void gpio_set_direction(volatile uint8_t *direction_register_addr, uint8_t data_direction_bit_field, bool state)
+// {
+//     *direction_register_addr = (state << data_direction_bit_field);
+// }
+// 
+// void gpio_set_output(volatile uint8_t* port_addr, uint8_t pin_bit_field, bool direction)
+// {
+//     *port_addr = (direction << pin_bit_field);
+// }

--- a/nodes/node_1/src/modules/include/usart.h
+++ b/nodes/node_1/src/modules/include/usart.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdio.h>
 
-void usart_init(uint16_t baud_rate);
-
-void usart_send_string(char *string);
-
-void usart_send_char(char character);
+FILE *usart_init(uint16_t baud_rate);
+int usart_put_char(char character, FILE *fd);
+int usart_get_char(FILE *fd);
+void usart_flush_receive_buffer();
+char usart_read_char();

--- a/nodes/node_1/src/modules/include/usart.h
+++ b/nodes/node_1/src/modules/include/usart.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdint.h>
+
+void usart_init(uint16_t baud_rate);
+
+void usart_send_string(char *string);
+
+void usart_send_char(char character);

--- a/nodes/node_1/src/modules/usart.c
+++ b/nodes/node_1/src/modules/usart.c
@@ -1,17 +1,13 @@
-// #include "gpio.h"
-#include <avr/interrupt.h>
 #include <avr/io.h>
-#include <util/delay.h>
 
 #include "usart.h"
 
 void usart_init(uint16_t baud_rate)
 {
+    const uint16_t my_ubrr = F_CPU / 16 / (baud_rate - 1);
 
-#define BAUD 9600
-#define MYUBRR (F_CPU / 16 / (BAUD - 1))
-    UBRR0H = (uint8_t)(MYUBRR >> 8);
-    UBRR0L = (uint8_t)MYUBRR;
+    UBRR0H = (uint8_t)(my_ubrr >> 8);
+    UBRR0L = (uint8_t)(my_ubrr);
 
     // one start bit
     // asynchronous mode

--- a/nodes/node_1/src/modules/usart.c
+++ b/nodes/node_1/src/modules/usart.c
@@ -1,0 +1,43 @@
+// #include "gpio.h"
+#include <avr/interrupt.h>
+#include <avr/io.h>
+#include <util/delay.h>
+
+#include "usart.h"
+
+void usart_init(uint16_t baud_rate)
+{
+
+#define BAUD 9600
+#define MYUBRR (F_CPU / 16 / (BAUD - 1))
+    UBRR0H = (uint8_t)(MYUBRR >> 8);
+    UBRR0L = (uint8_t)MYUBRR;
+
+    // one start bit
+    // asynchronous mode
+    // even parity bit
+    // one stop bit
+    // 8 data bits
+    // in total 11 bits per frame
+    // page 187 - 188
+    UCSR0C = (1 << URSEL0) | (0 << UMSEL0) | (1 << UPM01) | (0 << USBS0) | (3 << UCSZ00);
+
+    // enable transmit on USART0
+    UCSR0B = (1 << TXEN0); // | (1<<RXEN0);
+}
+void usart_send_string(char *string)
+{
+    while (*string)
+    {
+        usart_send_char(*string++);
+    }
+    usart_send_char('\0');
+}
+
+void usart_send_char(char character)
+{
+    // if UDRE0 bit inside UCSRA0 register is set then transmission can begin
+    while (!(UCSR0A & (1 << UDRE0)))
+        ;
+    UDR0 = character;
+}


### PR DESCRIPTION
- add UART support
- bind `stdout`, `stderr` and `stdin` to libc function calls like `printf()` and `gets()` 